### PR TITLE
feat: 브로커 연결, publish 구현

### DIFF
--- a/src/main/java/com/codecobain/mqtt_spring/config/MqttSpringConfig.java
+++ b/src/main/java/com/codecobain/mqtt_spring/config/MqttSpringConfig.java
@@ -1,0 +1,28 @@
+package com.codecobain.mqtt_spring.config;
+
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.beans.factory.annotation.Value;
+
+@EnableAsync
+@Configuration
+public class MqttSpringConfig {
+    // MQTT 클라이언트를 빈으로 등록하고 브로커와 연결
+    @Bean
+    public MqttClient mqttClient(@Value("${mqtt.clientId}") String clientId, @Value("${mqtt.hostname}") String hostname,
+            @Value("${mqtt.port}") int port)
+            throws MqttException {
+        MqttClient mqttClient = new MqttClient("tcp://" + hostname + ":" + port, clientId);
+
+        try {
+            mqttClient.connect();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return mqttClient;
+    }
+}

--- a/src/main/java/com/codecobain/mqtt_spring/controller/MqttSpringController.java
+++ b/src/main/java/com/codecobain/mqtt_spring/controller/MqttSpringController.java
@@ -1,0 +1,28 @@
+package com.codecobain.mqtt_spring.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.codecobain.mqtt_spring.dto.MqttMessagePublishRequestDto;
+import com.codecobain.mqtt_spring.service.MqttSpringService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class MqttSpringController {
+    private final MqttSpringService service;
+
+    @PostMapping("publish")
+    public ResponseEntity<?> messaggePublish(@RequestBody MqttMessagePublishRequestDto dto) {
+        try {
+            service.messagePublish(dto);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+        return ResponseEntity.ok("success to publish message");
+    }
+}

--- a/src/main/java/com/codecobain/mqtt_spring/dto/MqttMessagePublishRequestDto.java
+++ b/src/main/java/com/codecobain/mqtt_spring/dto/MqttMessagePublishRequestDto.java
@@ -1,0 +1,11 @@
+package com.codecobain.mqtt_spring.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MqttMessagePublishRequestDto {
+    private String topic;
+    private String message;
+}

--- a/src/main/java/com/codecobain/mqtt_spring/service/MqttSpringService.java
+++ b/src/main/java/com/codecobain/mqtt_spring/service/MqttSpringService.java
@@ -1,0 +1,32 @@
+package com.codecobain.mqtt_spring.service;
+
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.springframework.stereotype.Service;
+
+import com.codecobain.mqtt_spring.dto.MqttMessagePublishRequestDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MqttSpringService {
+    private final MqttClient client;
+
+    public void messagePublish(MqttMessagePublishRequestDto dto) {
+        String messageContent = dto.getMessage();
+
+        // publish할 메시지 생성
+        MqttMessage message = new MqttMessage();
+        message.setPayload(messageContent.getBytes());
+
+        // 클라이언트를 통해 현재 연결 중인 브로커에 메시지를 publish
+        try {
+            client.publish(dto.getTopic(), message);
+        } catch (MqttException e) {
+            e.printStackTrace();
+            System.out.println("fail to publish");
+        }
+    }
+}


### PR DESCRIPTION
브로커 연결:
- MQTT통신을 위한 브로커에 클라이언트로 연결
- 브로커의 ip, port와 클라이언트의 id 설정

publish 구현:
- 클라이언트를 이용하여 연결된 브로커에 메시지를 publish
- 토픽 설정으로 특정 사용자에게만 메시지 전달