### PR TITLE
feat($subscribe): mqtt메시지를 관리하기 위한 bean객체 생성, 등록

### DIFF
--- a/src/main/java/com/codecobain/mqtt_spring/config/MessageContainer.java
+++ b/src/main/java/com/codecobain/mqtt_spring/config/MessageContainer.java
@@ -1,0 +1,10 @@
+package com.codecobain.mqtt_spring.config;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class MessageContainer {
+    private String message;
+}

--- a/src/main/java/com/codecobain/mqtt_spring/config/MqttSpringConfig.java
+++ b/src/main/java/com/codecobain/mqtt_spring/config/MqttSpringConfig.java
@@ -6,10 +6,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-import lombok.RequiredArgsConstructor;
-
 import org.springframework.beans.factory.annotation.Value;
 
+// https://sonjuhy.tistory.com/45
+// https://velog.io/@jinony/Spring-Boot-MQTT%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EC%99%B8%EB%B6%80-API%EB%A1%9C%EC%9D%98-%EB%8D%B0%EC%9D%B4%ED%84%B0-%EC%86%A1%EC%88%98%EC%8B%A0
+// 스프링이 publish&callback감지, 단말기가 subscribe, 라즈베리파이 mosquitto가 broker
+// 토픽 이름으로 단말기 구별..?
+// 아래의 명령어로 브로커 먼저 실행
+// /opt/homebrew/opt/mosquitto/sbin/mosquitto -c /opt/homebrew/etc/mosquitto/mosquitto.conf
+// 아래 링크 참고해서 .lck파일 생성 문제 해결 찾아보기
+// https://stackoverflow.com/questions/66479612/eclipse-paho-mqtt-generates-a-lot-of-folders-containing-a-lck-file
+// 아래 맄크 참고해서 callback 구현
+// https://velog.io/@yeoonnii/mqtt-client
 
 @EnableAsync
 @Configuration
@@ -28,5 +36,11 @@ public class MqttSpringConfig {
         }
 
         return mqttClient;
+    }
+
+    // subscribe로 받아온 값을 전역으로 관리하기 위한 bean객체 등록
+    @Bean
+    public MessageContainer messageContainer() {
+        return new MessageContainer();
     }
 }


### PR DESCRIPTION
mqtt메시지를 관리하기 위한 bean객체 생성, 등록:
- mqttclient를 통해 subscribe한 topic의 가장 최근 메시지를 저장하는 messageContainer 생성
- 가장 최근에 발생한 메시지를 저장하고 전송하기 위해 messageContainer를 bean객체로 등록